### PR TITLE
✅ CI Test: fail if there are cabal warnings

### DIFF
--- a/.github/workflows/build-with-cabal.yaml
+++ b/.github/workflows/build-with-cabal.yaml
@@ -10,4 +10,6 @@ jobs:
         with:
           ghc-version: '9.6'
           cabal-version: '3.10.3.0'
+      - run: |
+          sed -i -e "s/ghc-options:/ghc-options: -Werror/" myocardio.cabal
       - run: cabal v2-build

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -682,7 +682,7 @@ data MuscleWithWeight = MuscleWithWeight
   }
 
 fromTuple :: (Muscle, Double) -> MuscleWithWeight
-fromTuple (m, w) = MuscleWithWeight m w
+fromTuple (m, w) = MuscleWithWeight {muscle = m, weight = w}
 
 muscleLens :: Muscle -> Traversal' Document (Map.Map Name Text)
 muscleLens muscle' = root . named "svg" ... named "path" . attributeSatisfies "id" (isPrefixOf (packShow muscle' <> "-")) . attrs


### PR DESCRIPTION
There seems to be no way of doing this, other than editing the actual cabal file on build. Bummer, but it works.

I had to fix one actual warning type in `Main.hs`, too, which was a good test.